### PR TITLE
Engine menu fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@glorious/pitsby",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glorious/pitsby",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Docs generator for AngularJS and Vue components",
   "author": "Rafael Camargo <hello@rafaelcamargo.com>",
   "repository": {

--- a/src/webapp/scripts/components/engine-menu/engine-menu.js
+++ b/src/webapp/scripts/components/engine-menu/engine-menu.js
@@ -18,17 +18,10 @@ function controller(routeService) {
     configMenuVisibility(projects);
     if(!isNoProjectSelected())
       selectProject(projects[0]);
-    onFetchProjectsComplete(projects);
   }
 
   function onFetchProjectsError(err){
     console.log('Failed to get projects', err);
-    onFetchProjectsComplete();
-  }
-
-  function onFetchProjectsComplete(projects){
-    if($ctrl.onLoadComplete)
-      $ctrl.onLoadComplete(projects);
   }
 
   function setProjects(projects){
@@ -58,9 +51,6 @@ function controller(routeService) {
 controller.$inject = ['routeService'];
 
 export default {
-  bindings: {
-    onLoadComplete: '<'
-  },
   controller,
   template
 };

--- a/src/webapp/scripts/components/engine-menu/engine-menu.test.js
+++ b/src/webapp/scripts/components/engine-menu/engine-menu.test.js
@@ -42,25 +42,6 @@ describe('Engine Menu', () => {
     expect(controller.projects).toEqual(projectsMock);
   });
 
-  it('should execute load complete callback on fetch complete if callback has been provided', () => {
-    const onLoadComplete = jest.fn();
-    const projectsMock = mockProjects();
-    const controller = compile({ onLoadComplete });
-    stubGetProjects('success', projectsMock);
-    controller.$onInit();
-    expect(onLoadComplete).toHaveBeenCalledWith(projectsMock);
-  });
-
-  it('should not execute load complete callback on fetch complete if callback has not been provided', () => {
-    const onLoadComplete = jest.fn();
-    const projectsMock = mockProjects();
-    const controller = compile({ onLoadComplete });
-    stubGetProjects('success', projectsMock);
-    delete controller.onLoadComplete;
-    controller.$onInit();
-    expect(onLoadComplete).not.toHaveBeenCalledWith(projectsMock);
-  });
-
   it('should show engine menu if more than one project is found', () => {
     const controller = compile();
     stubGetProjects('success', mockProjects());

--- a/src/webapp/scripts/components/index.js
+++ b/src/webapp/scripts/components/index.js
@@ -21,6 +21,7 @@ import rowItem from '@scripts/components/row-item/row-item';
 import sidebar from '@scripts/components/sidebar/sidebar';
 import tabs from '@scripts/components/tabs/tabs';
 import tab from '@scripts/components/tab/tab';
+import topbar from '@scripts/components/topbar/topbar';
 import viewport from '@scripts/components/viewport/viewport';
 import welcome from '@scripts/components/welcome/welcome';
 
@@ -47,6 +48,7 @@ export default angular.module('pitsby-components', [])
   .component('pSidebar', sidebar)
   .component('pTabs', tabs)
   .component('pTab', tab)
+  .component('pTopbar', topbar)
   .component('pViewport', viewport)
   .component('pWelcome', welcome)
   .name;

--- a/src/webapp/scripts/components/main/main.html
+++ b/src/webapp/scripts/components/main/main.html
@@ -1,6 +1,3 @@
 <main class="p-main {{ $ctrl.topOffsetCssClass }}">
-  <p-engine-menu
-    data-on-load-complete="$ctrl.onEngineMenuLoadComplete">
-  </p-engine-menu>
   <ng-transclude></ng-transclude>
 </main>

--- a/src/webapp/scripts/components/main/main.js
+++ b/src/webapp/scripts/components/main/main.js
@@ -4,12 +4,16 @@ import template from './main.html';
 function controller(){
   const $ctrl = this;
 
-  $ctrl.onEngineMenuLoadComplete = engines => {
-    setTopOffsetCssClass(buildTopOffsetCssClass(engines));
+  $ctrl.$onInit = () => {
+    setTopOffsetCssClass(buildTopOffsetCssClass());
   };
 
-  function buildTopOffsetCssClass(engines){
-    return engines && engines.length > 1 ? 'p-main-top-offset' : '';
+  function buildTopOffsetCssClass(){
+    return hasEngineMenu() ? 'p-main-top-offset' : '';
+  }
+
+  function hasEngineMenu(){
+    return document.querySelector('[data-engine-menu-container]');
   }
 
   function setTopOffsetCssClass(cssClass){

--- a/src/webapp/scripts/components/main/main.test.js
+++ b/src/webapp/scripts/components/main/main.test.js
@@ -14,6 +14,12 @@ describe('Main', () => {
     });
   });
 
+  afterEach(() => {
+    const fakeEngineMenuElement = document.querySelector('[data-engine-menu-container]');
+    if(fakeEngineMenuElement)
+      fakeEngineMenuElement.remove();
+  });
+
   it('should have appropriate css class', () => {
     const element = compile();
     expect(element.find('main').attr('class').trim()).toEqual('p-main');
@@ -29,19 +35,16 @@ describe('Main', () => {
     expect(element.find('p').text()).toEqual('Hello!');
   });
 
-  it('should set additional top margin to main content if engine menu has more than one engine', () => {
-    const engines = [{engine: 'angular'}, {engine: 'vue'}];
+  it('should set additional top margin to main content if engine menu is visible', () => {
+    const fakeEngineMenuElement = document.createElement('div');
+    fakeEngineMenuElement.setAttribute('data-engine-menu-container', '');
+    document.body.appendChild(fakeEngineMenuElement);
     const element = compile();
-    element.isolateScope().$ctrl.onEngineMenuLoadComplete(engines);
-    element.isolateScope().$digest();
     expect(element.find('main').hasClass('p-main-top-offset')).toEqual(true);
   });
 
-  it('should not set additional top margin to main content if engine menu has only one engine', () => {
-    const engines = [{engine: 'angular'}];
+  it('should not set additional top margin to main content if engine menu is not visible', () => {
     const element = compile();
-    element.isolateScope().$ctrl.onEngineMenuLoadComplete(engines);
-    element.isolateScope().$digest();
     expect(element.find('main').hasClass('p-main-top-offset')).toEqual(false);
   });
 });

--- a/src/webapp/scripts/components/topbar/topbar.html
+++ b/src/webapp/scripts/components/topbar/topbar.html
@@ -1,0 +1,3 @@
+<div class="p-topbar">
+  <p-engine-menu></p-engine-menu>
+</div>

--- a/src/webapp/scripts/components/topbar/topbar.js
+++ b/src/webapp/scripts/components/topbar/topbar.js
@@ -1,0 +1,5 @@
+import template from './topbar.html';
+
+export default {
+  template
+};

--- a/src/webapp/scripts/components/topbar/topbar.test.js
+++ b/src/webapp/scripts/components/topbar/topbar.test.js
@@ -1,0 +1,27 @@
+describe('Topbar', () => {
+  let compile;
+
+  beforeEach(() => {
+    angular.mock.module('pitsby-app');
+    inject(($rootScope, $compile) => {
+      compile = () => {
+        const scope = $rootScope.$new(true);
+        const template = '<p-topbar />';
+        const element = $compile(template)(scope);
+        scope.$digest();
+        return element;
+      };
+    });
+  });
+
+  it('should have appropriate css class', () => {
+    const element = compile();
+    expect(element.find('div').attr('class')).toEqual('p-topbar');
+  });
+
+  it('should contain a engine menu', () => {
+    const element = compile();
+    const engineMenu = element[0].querySelectorAll('p-engine-menu');
+    expect(engineMenu.length).toEqual(1);
+  });
+});

--- a/src/webapp/scripts/components/viewport/viewport.html
+++ b/src/webapp/scripts/components/viewport/viewport.html
@@ -1,6 +1,4 @@
 <div class="p-viewport">
-  <p-sidebar></p-sidebar>
-  <p-main>
-    <ng-transclude></ng-transclude>
-  </p-main>
+  <p-topbar></p-topbar>
+  <ng-transclude></ng-transclude>
 </div>

--- a/src/webapp/scripts/views/external-components.html
+++ b/src/webapp/scripts/views/external-components.html
@@ -1,3 +1,8 @@
-<ui-view>
-  <p-welcome></p-welcome>
-</ui-view>
+<div>
+  <p-sidebar></p-sidebar>
+  <p-main>
+    <ui-view>
+      <p-welcome></p-welcome>
+    </ui-view>
+  </p-main>
+</div>


### PR DESCRIPTION
The last release (1.9.0) removed topbar and moved engine menu from topbar to the new component called main. Since engine menu was responsible for fetching the engines used and redirecting users to the view the contains the components for the first engine found, an issue has raised.

This PR reorder things like they were before.

