### PR TITLE
Allow to use an external url as favicon href

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@glorious/pitsby",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glorious/pitsby",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "description": "Docs generator for AngularJS, Vue and Vanilla components",
   "author": "Rafael Camargo <hello@rafaelcamargo.com>",
   "repository": {

--- a/src/cli/services/webapp-html-index-customisation.js
+++ b/src/cli/services/webapp-html-index-customisation.js
@@ -12,8 +12,12 @@ function handleFavicon({ filepath } = {}, template){
 }
 
 function buildFaviconHref(filepath){
-  const href = filepath ? path.join('external', filepath) : 'images/favicon-pitsby.png';
+  const href = filepath ? buildCustomFaviconHref(filepath) : 'images/favicon-pitsby.png';
   return `${href}?t=${Date.now()}`;
+}
+
+function buildCustomFaviconHref(filepath){
+  return filepath.includes('http') ? filepath :path.join('external', filepath);
 }
 
 function handleWindowTitle(title = 'Pitsby', template){

--- a/src/cli/services/webapp-html-index-customisation.test.js
+++ b/src/cli/services/webapp-html-index-customisation.test.js
@@ -28,6 +28,13 @@ describe('Webapp HTML Index Customisation', () => {
     expect(template.includes('<link href="external/dist/images/favicon.png?t=123" rel="shortcut icon">')).toEqual(true);
   });
 
+  it('should set custom favicon external href on template if it has been given', () => {
+    const template = webappHtmlIndexCustomisation.init(buildTemplateMock(), {
+      favicon: { filepath: 'https://some.other.domain/images/favicon.png' }
+    });
+    expect(template.includes('<link href="https://some.other.domain/images/favicon.png?t=123" rel="shortcut icon">')).toEqual(true);
+  });
+
   it('should set Pitsby window title on template by default', () => {
     const template = webappHtmlIndexCustomisation.init(buildTemplateMock());
     expect(template.includes('<title>Pitsby</title>')).toEqual(true);


### PR DESCRIPTION
Minor improvement to this: https://github.com/glorious-codes/glorious-pitsby/issues/78