### PR TITLE
Add support for angular components lifecycle hooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@glorious/pitsby",
-  "version": "1.27.8",
+  "version": "1.28.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glorious/pitsby",
-  "version": "1.27.8",
+  "version": "1.28.0",
   "description": "Docs generator for AngularJS, React, Vue and Vanilla components",
   "author": "Rafael Camargo <hello@rafaelcamargo.com>",
   "repository": {

--- a/src/webapp/scripts/services/angular-component-builder.test.js
+++ b/src/webapp/scripts/services/angular-component-builder.test.js
@@ -1,5 +1,5 @@
 describe('Angular Component Builder', () => {
-  let service, $scope, $window;
+  let service, $scope, $window, $timeout;
 
   function compileComponent(component, scope){
     const element = service.build(component, scope);
@@ -7,11 +7,16 @@ describe('Angular Component Builder', () => {
     return element;
   }
 
+  function buildComponent(controller, dependencies){
+    return { controller, template: '<div></div>', dependencies };
+  }
+
   beforeEach(() => {
     angular.mock.module('pitsby-app');
     inject(($rootScope, $injector) => {
       $scope = $rootScope.$new(true);
       $window = $injector.get('$window');
+      $timeout = $injector.get('$timeout');
       service = $injector.get('angularComponentBuilder');
     });
   });
@@ -53,5 +58,61 @@ describe('Angular Component Builder', () => {
     const element = compileComponent(component, $scope);
     expect(element.triggerHandler('click'));
     expect($window.alert).toHaveBeenCalledWith('Rafael');
+  });
+
+  it('should execute initialization hook if controller uses it', () => {
+    window.alert = jest.fn();
+    const component = buildComponent(function(){
+      const $ctrl = this;
+      $ctrl.$onInit = () => window.alert();
+    });
+    compileComponent(component, $scope);
+    $timeout.flush();
+    expect(window.alert.mock.calls.length).toEqual(1);
+  });
+
+  it('should not execute initialization hook if controller does not use it', () => {
+    window.alert = jest.fn();
+    const component = buildComponent(function(){
+      const $ctrl = this;
+      $ctrl.onInit = () => window.alert();
+    });
+    compileComponent(component, $scope);
+    $timeout.flush();
+    expect(window.alert.mock.calls.length).toEqual(0);
+  });
+
+  it('should not execute initialization automatically hook if controller calls it manually', () => {
+    window.alert = jest.fn();
+    const component = buildComponent(function(){
+      const $ctrl = this;
+      $ctrl.$onInit = () => window.alert();
+      $ctrl.$onInit();
+    });
+    compileComponent(component, $scope);
+    expect(window.alert.mock.calls.length).toEqual(1);
+  });
+
+  it('should not execute initialization automatically hook if controller calls it manually inside $timeout', () => {
+    window.alert = jest.fn();
+    const component = buildComponent(function($timeout){
+      const $ctrl = this;
+      $ctrl.$onInit = () => window.alert();
+      $timeout($ctrl.$onInit);
+    }, ['$timeout']);
+    compileComponent(component, $scope);
+    $timeout.flush();
+    expect(window.alert.mock.calls.length).toEqual(1);
+  });
+
+  it('should execute destruction hook if controller uses it', () => {
+    window.alert = jest.fn();
+    const component = buildComponent(function(){
+      const $ctrl = this;
+      $ctrl.$onDestroy = () => window.alert();
+    });
+    compileComponent(component, $scope);
+    $scope.$destroy();
+    expect(window.alert.mock.calls.length).toEqual(1);
   });
 });


### PR DESCRIPTION
Angular components written in docs or in the playground have no lifecycle hooks support.
This PR introduces the necessary changes to make it happen. From now on, it's no longer necessary call those hooks manually.