### PR TITLE
Add Lifecycle hooks support for React and Vue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@glorious/pitsby",
-  "version": "1.28.0",
+  "version": "1.29.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glorious/pitsby",
-  "version": "1.28.0",
+  "version": "1.29.0",
   "description": "Docs generator for AngularJS, React, Vue and Vanilla components",
   "author": "Rafael Camargo <hello@rafaelcamargo.com>",
   "repository": {

--- a/src/webapp/scripts/components/external-component-preview/external-component-preview.js
+++ b/src/webapp/scripts/components/external-component-preview/external-component-preview.js
@@ -14,8 +14,11 @@ function controller($scope, $timeout, $element, angularComponentBuilder){
   };
 
   $ctrl.$onDestroy = () => {
-    if($ctrl.pageFoldSubscriptionId)
-      unsubscribeFromPageFoldService($ctrl.pageFoldSubscriptionId);
+    const { engine, instance, pageFoldSubscriptionId } = $ctrl;
+    if(pageFoldSubscriptionId)
+      unsubscribeFromPageFoldService(pageFoldSubscriptionId);
+    if(instance)
+      externalComponentsPreviewRenderer.destroy(engine, instance);
   };
 
   function onShowUp(){
@@ -50,12 +53,13 @@ function controller($scope, $timeout, $element, angularComponentBuilder){
   }
 
   function buildComponent(engine, component){
-    externalComponentsPreviewRenderer.render(engine, component, {
+    const instance = externalComponentsPreviewRenderer.render(engine, component, {
       container: getContainer()[0],
       scope: $scope,
       angularContainer: getContainer(),
       angularComponentBuilder
     });
+    setInstance(instance);
   }
 
   function getContainer(){
@@ -72,6 +76,10 @@ function controller($scope, $timeout, $element, angularComponentBuilder){
 
   function setRendered(rendered){
     $ctrl.rendered = rendered;
+  }
+
+  function setInstance(instance){
+    $ctrl.instance = instance;
   }
 }
 

--- a/src/webapp/scripts/components/external-component-preview/external-component-preview.test.js
+++ b/src/webapp/scripts/components/external-component-preview/external-component-preview.test.js
@@ -32,7 +32,7 @@ describe('External Component Preview', () => {
         scope.$digest();
         return element;
       };
-      externalComponentsPreviewRenderer.onDestroy = jest.fn();
+      externalComponentsPreviewRenderer.destroy = jest.fn();
       externalComponentsPreviewRenderer.render = jest.fn();
       jsonService.handleFunctions = jest.fn((component) => component);
       pageFoldService.subscribe = jest.fn((element, onShowUp) => onShowUp());
@@ -89,11 +89,21 @@ describe('External Component Preview', () => {
     expect(element.find('style')[0].innerHTML).toEqual(stylesMock);
   });
 
-  it('should unregistered itself from page fold service on destroy if example has not been build', () => {
+  it('should unregister itself from page fold service on destroy if example has been built', () => {
     pageFoldService.unsubscribe = jest.fn();
     pageFoldService.subscribe = jest.fn(() => '123');
     const element = compile({engine: 'angular', example: mockExample()});
     element.isolateScope().$ctrl.$onDestroy();
     expect(pageFoldService.unsubscribe).toHaveBeenCalledWith('123');
+  });
+
+  it('should unbuild example if it has been built', () => {
+    const instanceMock = {};
+    externalComponentsPreviewRenderer.render = jest.fn(() => instanceMock);
+    pageFoldService.subscribe = jest.fn((element, onShowUp) => onShowUp());
+    const element = compile({engine: 'react', example: mockExample()});
+    const $ctrl = element.isolateScope().$ctrl;
+    $ctrl.$onDestroy();
+    expect(externalComponentsPreviewRenderer.destroy).toHaveBeenCalledWith('react', instanceMock);
   });
 });

--- a/src/webapp/scripts/services/external-components-preview-renderer.js
+++ b/src/webapp/scripts/services/external-components-preview-renderer.js
@@ -8,7 +8,16 @@ _public.render = (engine, component, { container, scope, angularComponentBuilder
   if(engine == 'angular')
     renderAngularComponent(angularComponentBuilder, angularContainer, scope, component);
   else
-    getComponentRenderer(engine)(component, container);
+    return getComponentRenderer(engine)(component, container);
+};
+
+_public.destroy = (engine, instance) => {
+  switch (engine) {
+  case 'react':
+    return reactComponentBuilder.unbuild(instance);
+  case 'vue':
+    return vueComponentBuilder.unbuild(instance);
+  }
 };
 
 function getComponentRenderer(engine){
@@ -31,10 +40,12 @@ function renderAngularComponent(builder, container, scope, component){
 function renderReactComponent({ controller }, container){
   const element = reactComponentBuilder.build(controller);
   ReactDOM.render(element, container);
+  return container;
 }
 
 function renderVueComponent(component, container){
-  vueComponentBuilder.build(component, container);
+  const vm = vueComponentBuilder.build(component, container);
+  return vm;
 }
 
 function renderVanillaComponent(component, container){

--- a/src/webapp/scripts/services/external-components-preview-renderer.test.js
+++ b/src/webapp/scripts/services/external-components-preview-renderer.test.js
@@ -60,4 +60,18 @@ describe('External Component Preview Renderer Service', () => {
     externalComponentsPreviewRenderer.render('vue', component, { container });
     expect(vueComponentBuilder.build).toHaveBeenCalledWith(component, container);
   });
+
+  it('should unbuild a React component on destroy if engine passed is React', () => {
+    const instanceMock = {};
+    reactComponentBuilder.unbuild = jest.fn();
+    externalComponentsPreviewRenderer.destroy('react', instanceMock);
+    expect(reactComponentBuilder.unbuild).toHaveBeenCalledWith(instanceMock);
+  });
+
+  it('should unbuild a Vue component on destroy if engine passed is Vue', () => {
+    const instanceMock = {};
+    vueComponentBuilder.unbuild = jest.fn();
+    externalComponentsPreviewRenderer.destroy('vue', instanceMock);
+    expect(vueComponentBuilder.unbuild).toHaveBeenCalledWith(instanceMock);
+  });
 });

--- a/src/webapp/scripts/services/react-component-builder.js
+++ b/src/webapp/scripts/services/react-component-builder.js
@@ -7,6 +7,10 @@ _public.build = controller => {
   return React.createElement(Component);
 };
 
+_public.unbuild = container => {
+  ReactDOM.unmountComponentAtNode(container);
+};
+
 function transpileController(controller){
   const transpiledCode = transform(wrapControllerInModuleExports(controller), {
     presets: ['env', 'react']

--- a/src/webapp/scripts/services/react-component-builder.test.js
+++ b/src/webapp/scripts/services/react-component-builder.test.js
@@ -22,4 +22,11 @@ describe('React Component Builder', () => {
     ReactDOM.render(builtComponent, container);
     expect(container.querySelector('h1').textContent).toEqual('Hello!');
   });
+
+  it('should unbuild a react component', () => {
+    const containerMock = document.createElement('div');
+    ReactDOM.unmountComponentAtNode = jest.fn();
+    reactComponentBuilder.unbuild(containerMock);
+    expect(ReactDOM.unmountComponentAtNode).toHaveBeenCalledWith(containerMock);
+  });
 });

--- a/src/webapp/scripts/services/vue-component-builder.js
+++ b/src/webapp/scripts/services/vue-component-builder.js
@@ -6,4 +6,8 @@ _public.build = ({controller = {}, template = ''} = {}, container) => {
   return vm;
 };
 
+_public.unbuild = vm => {
+  vm.$destroy();
+};
+
 export default _public;

--- a/src/webapp/scripts/services/vue-component-builder.test.js
+++ b/src/webapp/scripts/services/vue-component-builder.test.js
@@ -52,4 +52,10 @@ describe('Vue Component Builder', () => {
     vueComponentBuilder.build(undefined, container);
     expect(container.innerHTML).toEqual('');
   });
+
+  it('should unbuild a Vue component', () => {
+    const vmMock = { $destroy: jest.fn() };
+    vueComponentBuilder.unbuild(vmMock);
+    expect(vmMock.$destroy).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Unmount lifecycle hooks were not supported. This PR introduces the necessary changes to make that happen.