### PR TITLE
Minor visual improvement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@glorious/pitsby",
-  "version": "1.30.2",
+  "version": "1.30.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glorious/pitsby",
-  "version": "1.30.2",
+  "version": "1.30.3",
   "description": "Docs generator for AngularJS, React, Vue and Vanilla components",
   "author": "Rafael Camargo <hello@rafaelcamargo.com>",
   "repository": {
@@ -27,7 +27,9 @@
     "SPA"
   ],
   "license": "MIT",
-  "bin": "./src/cli/index.js",
+  "bin": {
+    "pitsby": "src/cli/index.js"
+  },
   "scripts": {
     "build": "./node_modules/webpack/bin/webpack.js",
     "build:ci": "node ./.circleci/prepare && ./node_modules/webpack/bin/webpack.js --output-path=./dist",

--- a/src/webapp/styles/tabs.styl
+++ b/src/webapp/styles/tabs.styl
@@ -33,6 +33,6 @@
 .p-tabs-content
   padding 30px
   background-color alpha($color-grey-semi-light, 0.25)
-  overflow-x scroll
+  overflow-x auto
   overflow-y visible
   box-sizing(border-box)


### PR DESCRIPTION
In operating systems other than Mac, every doc example shows a scroll bar (even when it's not necessary). This PR adjusts its `overflow-x` to only show a scroll bar when it's necessary.