### PR TITLE
Extract standalone babel

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,6 +15,7 @@
     "module": true,
     "spyOn": true,
     "angular": true,
+    "Babel": true,
     "React": true,
     "ReactDOM": true,
     "Vue": true,

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -3,6 +3,7 @@ import 'angular';
 // angular.mock.module function vanishes from the API and all tests break.
 import 'angular-mocks';
 import path from 'path';
+import * as Babel from '@babel/standalone/babel.min'
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Vue from 'vue/dist/vue.min';
@@ -12,6 +13,7 @@ import project from './project.json';
 // and its dependencies
 require(path.join(__dirname, project.scripts.webapp.source.indexTemplate));
 
+global.Babel = Babel;
 global.Vue = Vue;
 global.React = React;
 global.ReactDOM = ReactDOM;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@glorious/pitsby",
-  "version": "1.30.13",
+  "version": "1.30.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@glorious/pitsby",
-      "version": "1.30.13",
+      "version": "1.30.14",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.18.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glorious/pitsby",
-  "version": "1.30.13",
+  "version": "1.30.14",
   "description": "Docs generator for AngularJS, React, Vue and Vanilla components",
   "author": "Rafael Camargo <hello@rafaelcamargo.com>",
   "repository": {

--- a/project.json
+++ b/project.json
@@ -13,7 +13,7 @@
       },
       "dist": {
         "filename": {
-          "prod": "[name]-[hash].js",
+          "prod": "[name]-[contenthash].js",
           "dev": "[name].js"
         }
       }
@@ -30,7 +30,7 @@
     },
     "dist": {
       "filename": {
-        "prod": "[name]-[hash].css",
+        "prod": "[name]-[contenthash].css",
         "dev": "[name].css"
       }
     }

--- a/src/cli/services/cdn.js
+++ b/src/cli/services/cdn.js
@@ -10,7 +10,8 @@ _public.buildAngularScriptTag = () => {
 _public.buildReactScriptTag = (version = '16.13.0') => {
   return [
     buildReactScriptTag(version, 'react'),
-    buildReactScriptTag(version, 'react-dom')
+    buildReactScriptTag(version, 'react-dom'),
+    buildUnpkgCdnScriptTag('@babel/standalone', '7.8.6', 'babel.min.js')
   ].join('\n');
 };
 
@@ -41,14 +42,17 @@ function buildEngineFileName(engine){
 }
 
 function buildReactScriptTag(version, lib){
-  const filename = buildReactLibFilename(lib);
-  const cdnUrl = `https://unpkg.com/${lib}@${version}/umd/${filename}`;
-  return `<script crossorigin src="${cdnUrl}"></script>`;
+  return buildUnpkgCdnScriptTag(lib, version, buildReactLibFilepath(lib));
 }
 
-function buildReactLibFilename(lib){
+function buildReactLibFilepath(lib){
   const suffix = processService.getNodeEnv() == 'production' ? 'production.min' : 'development';
-  return `${lib}.${suffix}.js`;
+  return `umd/${lib}.${suffix}.js`;
+}
+
+function buildUnpkgCdnScriptTag(lib, version, filepath){
+  const cdnUrl = `https://unpkg.com/${lib}@${version}/${filepath}`;
+  return `<script crossorigin src="${cdnUrl}"></script>`;
 }
 
 module.exports = _public;

--- a/src/cli/services/cdn.test.js
+++ b/src/cli/services/cdn.test.js
@@ -10,7 +10,7 @@ describe('CDN Service', () => {
     mockNodeEnv();
   });
 
-  it('should build scripts tag for Angular 1.8.0 by default', () => {
+  it('should build scripts tag for Angular 1.8.3 by default', () => {
     expect(service.buildAngularScriptTag()).toEqual(
       '<script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.8.3/angular.js"></script>'
     );
@@ -45,7 +45,8 @@ describe('CDN Service', () => {
   it('should build scripts tag for React 16.13.0 by default', () => {
     expect(service.buildReactScriptTag()).toEqual([
       '<script crossorigin src="https://unpkg.com/react@16.13.0/umd/react.development.js"></script>',
-      '<script crossorigin src="https://unpkg.com/react-dom@16.13.0/umd/react-dom.development.js"></script>'
+      '<script crossorigin src="https://unpkg.com/react-dom@16.13.0/umd/react-dom.development.js"></script>',
+      '<script crossorigin src="https://unpkg.com/@babel/standalone@7.8.6/babel.min.js"></script>'
     ].join('\n'));
   });
 
@@ -53,14 +54,16 @@ describe('CDN Service', () => {
     mockNodeEnv('production');
     expect(service.buildReactScriptTag()).toEqual([
       '<script crossorigin src="https://unpkg.com/react@16.13.0/umd/react.production.min.js"></script>',
-      '<script crossorigin src="https://unpkg.com/react-dom@16.13.0/umd/react-dom.production.min.js"></script>'
+      '<script crossorigin src="https://unpkg.com/react-dom@16.13.0/umd/react-dom.production.min.js"></script>',
+      '<script crossorigin src="https://unpkg.com/@babel/standalone@7.8.6/babel.min.js"></script>'
     ].join('\n'));
   });
 
   it('shuold optionally build script tag for custom React version', () => {
     expect(service.buildReactScriptTag('16.8.0')).toEqual([
       '<script crossorigin src="https://unpkg.com/react@16.8.0/umd/react.development.js"></script>',
-      '<script crossorigin src="https://unpkg.com/react-dom@16.8.0/umd/react-dom.development.js"></script>'
+      '<script crossorigin src="https://unpkg.com/react-dom@16.8.0/umd/react-dom.development.js"></script>',
+      '<script crossorigin src="https://unpkg.com/@babel/standalone@7.8.6/babel.min.js"></script>'
     ].join('\n'));
   });
 });

--- a/src/cli/services/webapp-html-index-generator.test.js
+++ b/src/cli/services/webapp-html-index-generator.test.js
@@ -191,6 +191,7 @@ describe('Webapp HTML Index Generator', () => {
     <script src="https://ajax.googleapis.com/ajax/libs/angularjs/${getAngularVersion()}/angular.js"></script>
     <script crossorigin src="https://unpkg.com/react@16.13.0/umd/react.development.js"></script>
 <script crossorigin src="https://unpkg.com/react-dom@16.13.0/umd/react-dom.development.js"></script>
+<script crossorigin src="https://unpkg.com/@babel/standalone@7.8.6/babel.min.js"></script>
   </body>
 </html>
 `);
@@ -218,6 +219,7 @@ describe('Webapp HTML Index Generator', () => {
     <script src="https://ajax.googleapis.com/ajax/libs/angularjs/${getAngularVersion()}/angular.js"></script>
     <script crossorigin src="https://unpkg.com/react@16.8.0/umd/react.development.js"></script>
 <script crossorigin src="https://unpkg.com/react-dom@16.8.0/umd/react-dom.development.js"></script>
+<script crossorigin src="https://unpkg.com/@babel/standalone@7.8.6/babel.min.js"></script>
   </body>
 </html>
 `);

--- a/src/webapp/scripts/components/engine-menu/engine-menu.html
+++ b/src/webapp/scripts/components/engine-menu/engine-menu.html
@@ -2,10 +2,7 @@
   ng-if="$ctrl.shouldShowMenu"
   data-engine-menu-container>
   <ul class="p-engine-menu">
-    <li
-      ng-repeat="project in $ctrl.projects"
-      style="width: {{ $ctrl.itemsWidth }};"
-      class="p-engine-menu-item">
+    <li ng-repeat="project in $ctrl.projects" class="p-engine-menu-item">
       <a
         ng-bind="project.engine"
         class="p-engine-menu-link"

--- a/src/webapp/scripts/components/engine-menu/engine-menu.js
+++ b/src/webapp/scripts/components/engine-menu/engine-menu.js
@@ -11,7 +11,6 @@ function controller() {
 
   function onFetchProjectsSuccess(projects){
     setProjects(projects);
-    setItemsWidth(buildItemsWidth(projects.length));
     configMenuVisibility(projects);
   }
 
@@ -21,14 +20,6 @@ function controller() {
 
   function setProjects(projects){
     $ctrl.projects = projects;
-  }
-
-  function buildItemsWidth(numberOfProjects){
-    return `${parseFloat(100 / numberOfProjects).toFixed(3)}%`;
-  }
-
-  function setItemsWidth(width){
-    $ctrl.itemsWidth = width;
   }
 
   function configMenuVisibility(projects){

--- a/src/webapp/scripts/components/engine-menu/engine-menu.test.js
+++ b/src/webapp/scripts/components/engine-menu/engine-menu.test.js
@@ -39,14 +39,6 @@ describe('Engine Menu', () => {
     expect(controller.projects).toEqual(projectsMock);
   });
 
-  it('should set items width on get projects success', () => {
-    const projectsMock = mockProjects();
-    const controller = compile();
-    stubGetProjects('success', projectsMock);
-    controller.$onInit();
-    expect(controller.itemsWidth).toEqual('50.000%');
-  });
-
   it('should show engine menu if more than one project is found', () => {
     const controller = compile();
     stubGetProjects('success', mockProjects());

--- a/src/webapp/scripts/services/react-component-builder.js
+++ b/src/webapp/scripts/services/react-component-builder.js
@@ -1,5 +1,3 @@
-import { transform } from '@babel/standalone';
-
 const _public = {};
 
 _public.build = controller => {
@@ -12,7 +10,7 @@ _public.unbuild = container => {
 };
 
 function transpileController(controller){
-  const transpiledCode = transform(wrapControllerInModuleExports(controller), {
+  const transpiledCode = Babel.transform(wrapControllerInModuleExports(controller), {
     presets: ['env', 'react']
   }).code;
   return convertExportedModuleToIIFE(transpiledCode);

--- a/src/webapp/styles/engine-menu.styl
+++ b/src/webapp/styles/engine-menu.styl
@@ -7,6 +7,7 @@
   clearfix()
 
 .p-engine-menu
+  display flex
   position relative
   bottom -1px
   margin 0
@@ -15,7 +16,8 @@
   clearfix()
 
 .p-engine-menu-item
-  float left
+  flex-basis 25%
+  flex-grow 2
 
 .p-engine-menu-link
   display block

--- a/webpack.conf.base.js
+++ b/webpack.conf.base.js
@@ -8,6 +8,7 @@ module.exports = {
   entry: [`${__dirname}/${project.scripts.webapp.source.index}`],
   externals: {
     'angular': 'angular',
+    '@babel/standalone': 'Babel',
     'react': 'React',
     'react-dom': 'ReactDOM',
     'vue': 'Vue'


### PR DESCRIPTION
This PR introduces the necessary changes to keep standalone babel out of the main bundle. It is now injected globally via script tag only for the cases in which clients are documenting React components.