### PR TITLE
Add ability to set attributes for external assets html tags

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -28,7 +28,7 @@
     "quotes": ["error", "single"],
     "semi": ["error", "always"],
     "complexity": ["error", { "max": 3 }],
-    "max-lines": ["error", { "max": 115 }],
+    "max-lines": ["error", { "max": 150 }],
     "max-statements": ["error", { "max": 5 },
       { "ignoreTopLevelFunctions": true }
     ]
@@ -37,7 +37,7 @@
     {
       "files": [ "src/**/*.test.js" ],
       "rules": {
-        "max-lines": ["error", { "max": 250 }],
+        "max-lines": ["error", { "max": 275 }],
         "max-statements": ["error", { "max": 15 },
           { "ignoreTopLevelFunctions": true }
         ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@glorious/pitsby",
-  "version": "1.31.0",
+  "version": "1.32.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@glorious/pitsby",
-      "version": "1.31.0",
+      "version": "1.32.0",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.18.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glorious/pitsby",
-  "version": "1.31.0",
+  "version": "1.32.0",
   "description": "Docs generator for AngularJS, React, Vue and Vanilla components",
   "author": "Rafael Camargo <hello@rafaelcamargo.com>",
   "repository": {


### PR DESCRIPTION
Ref.: https://github.com/glorious-codes/glorious-pitsby/issues/223

This Pull Request introduces the necessary changes to allow Pitsby users to set attributes to the generated HTML tags that will import *Styles* and *Scripts* set in Pitsby configuration file.

At this moment, users are limited to set a script `src` or a stylesheet `href`. With these new changes, users will be able to pass HTML attributes other than just `src` or `href`. See below:

``` javascript
// pitsby.config.js

module.exports = {

  // Current API
  styles: ['./dist/components.css', './dist/other.css'],
  scripts: ['./dist/components.js', './dist/custom.js', 'https://some.cdn.com/lib.js', './other.js']

  // Proposed API
  styles: [
    { rel: 'prefetch', href: './dist/other.css', as: 'style' },
    './dist/components.css'
  ],
  scripts: [
    { rel: 'preload', href: './dist/custom.js', as: 'script' },
    { type: 'module', src: './dist/components.js' },
    { crossorigin: '', src: 'https://some.cdn.com/lib.js' },
    './other.js'
  ]
}
```
