### PR TITLE
Lazy load code editor

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -4,7 +4,7 @@ import 'angular';
 import 'angular-mocks';
 import path from 'path';
 import * as Babel from '@babel/standalone/babel.min'
-import GAnalytics from '@glorious/analytics';
+import Staly from '@compilorama/staly';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Vue from 'vue/dist/vue.min';
@@ -13,7 +13,7 @@ import project from './project.json';
 // Needs to be mocked before importing index template, otherwise
 // Analytics Service will be imported, cached and it won't be
 // "mockable" anymore.
-jest.mock('@glorious/analytics');
+jest.mock('@compilorama/staly');
 
 // Import index template to register pitsby-app angular module
 // and its dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@babel/core": "^7.18.9",
         "@babel/preset-env": "^7.18.9",
         "@babel/standalone": "^7.8.6",
-        "@glorious/analytics": "^0.4.0",
+        "@compilorama/staly": "^0.4.1",
         "@glorious/fyzer": "^0.1.2",
         "@glorious/rasket": "^0.1.3",
         "@uirouter/angularjs": "^1.0.20",
@@ -1819,6 +1819,17 @@
         "node": ">=0.1.95"
       }
     },
+    "node_modules/@compilorama/staly": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@compilorama/staly/-/staly-0.4.1.tgz",
+      "integrity": "sha512-Etmx3P/pr3E8WWnTANfMb0KHv/1jk1XV9KutGYPvboUl5v+QpwzIZtwSmtpYQseErUcBH3nJBjF8VLWRvSfNAg==",
+      "dependencies": {
+        "@glorious/cookie": "^0.3.0",
+        "isbot": "^3.5.0",
+        "plausible-tracker": "^0.3.1",
+        "query-string": "^7.0.1"
+      }
+    },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -1913,17 +1924,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@glorious/analytics": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@glorious/analytics/-/analytics-0.4.0.tgz",
-      "integrity": "sha512-kKHDH3OfPlWXViSiIaxpR+qDKojpbxaZR1bKFU3Iz75+OvlxBlAfySYzu2gMcCT8BWrx/alc7DNr0FfiYe/n9g==",
-      "dependencies": {
-        "@glorious/cookie": "^0.3.0",
-        "isbot": "^3.5.0",
-        "plausible-tracker": "^0.3.1",
-        "query-string": "^7.0.1"
       }
     },
     "node_modules/@glorious/cookie": {
@@ -7910,9 +7910,9 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "node_modules/isbot": {
-      "version": "3.6.6",
-      "resolved": "https://registry.npmjs.org/isbot/-/isbot-3.6.6.tgz",
-      "integrity": "sha512-98aGl1Spbx1led422YFrusDJ4ZutSNOymb2avZ2V4BCCjF3MqAF2k+J2zoaLYahubaFkb+3UyvbVDVlk/Ngrew==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/isbot/-/isbot-3.7.1.tgz",
+      "integrity": "sha512-JfqOaY3O1lcWt2nc+D6Mq231CNpwZrBboLa59Go0J8hjGH+gY/Sy0CA/YLUSIScINmAVwTdJZIsOTk4PfBtRuw==",
       "engines": {
         "node": ">=12"
       }
@@ -16380,6 +16380,17 @@
         "minimist": "^1.2.0"
       }
     },
+    "@compilorama/staly": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@compilorama/staly/-/staly-0.4.1.tgz",
+      "integrity": "sha512-Etmx3P/pr3E8WWnTANfMb0KHv/1jk1XV9KutGYPvboUl5v+QpwzIZtwSmtpYQseErUcBH3nJBjF8VLWRvSfNAg==",
+      "requires": {
+        "@glorious/cookie": "^0.3.0",
+        "isbot": "^3.5.0",
+        "plausible-tracker": "^0.3.1",
+        "query-string": "^7.0.1"
+      }
+    },
     "@discoveryjs/json-ext": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -16447,17 +16458,6 @@
           "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
           "dev": true
         }
-      }
-    },
-    "@glorious/analytics": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@glorious/analytics/-/analytics-0.4.0.tgz",
-      "integrity": "sha512-kKHDH3OfPlWXViSiIaxpR+qDKojpbxaZR1bKFU3Iz75+OvlxBlAfySYzu2gMcCT8BWrx/alc7DNr0FfiYe/n9g==",
-      "requires": {
-        "@glorious/cookie": "^0.3.0",
-        "isbot": "^3.5.0",
-        "plausible-tracker": "^0.3.1",
-        "query-string": "^7.0.1"
       }
     },
     "@glorious/cookie": {
@@ -21053,9 +21053,9 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isbot": {
-      "version": "3.6.6",
-      "resolved": "https://registry.npmjs.org/isbot/-/isbot-3.6.6.tgz",
-      "integrity": "sha512-98aGl1Spbx1led422YFrusDJ4ZutSNOymb2avZ2V4BCCjF3MqAF2k+J2zoaLYahubaFkb+3UyvbVDVlk/Ngrew=="
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/isbot/-/isbot-3.7.1.tgz",
+      "integrity": "sha512-JfqOaY3O1lcWt2nc+D6Mq231CNpwZrBboLa59Go0J8hjGH+gY/Sy0CA/YLUSIScINmAVwTdJZIsOTk4PfBtRuw=="
     },
     "isexe": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@babel/core": "^7.18.9",
     "@babel/preset-env": "^7.18.9",
     "@babel/standalone": "^7.8.6",
-    "@glorious/analytics": "^0.4.0",
+    "@compilorama/staly": "^0.4.1",
     "@glorious/fyzer": "^0.1.2",
     "@glorious/rasket": "^0.1.3",
     "@uirouter/angularjs": "^1.0.20",

--- a/src/webapp/mocks/glorious-analytics.js
+++ b/src/webapp/mocks/glorious-analytics.js
@@ -1,6 +1,0 @@
-export const ganalyticsInstanceMock = {
-  init: jest.fn(),
-  trackPageview: jest.fn()
-};
-
-export const GAnalyticsMock = jest.fn(() => ganalyticsInstanceMock);

--- a/src/webapp/mocks/staly.js
+++ b/src/webapp/mocks/staly.js
@@ -1,0 +1,6 @@
+export const stalyInstanceMock = {
+  init: jest.fn(),
+  trackPageview: jest.fn()
+};
+
+export const stalyMock = jest.fn(() => stalyInstanceMock);

--- a/src/webapp/scripts/components/code-editor/code-editor.js
+++ b/src/webapp/scripts/components/code-editor/code-editor.js
@@ -1,27 +1,27 @@
-import * as ace from 'brace';
-import 'brace/mode/javascript';
-import 'brace/mode/jsx';
-import 'brace/mode/html';
-import 'brace/mode/css';
-import '@styles/code-editor.styl';
+import codeEditorService from '@scripts/services/code-editor';
 import template from './code-editor.html';
 
 function controller($timeout, $element){
   const $ctrl = this;
 
   $ctrl.$onInit = () => {
-    $timeout(() => {
-      setEditor(ace.edit(getEditorHostElement()));
-      setEditorMode(buildModePath($ctrl.mode));
-      setEditorOptions({ tabSize: 2 });
-      setEditorCode($ctrl.code);
-      listenChanges();
+    codeEditorService.load().then(ace => {
+      $timeout(() => {
+        setEditor(ace.edit(getEditorHostElement()));
+        $ctrl.configEditor();
+      });
     });
   };
 
   $ctrl.handleChange = () => {
-    if($ctrl.onChange)
-      $ctrl.onChange(getSession().getValue());
+    $ctrl.onChange && $ctrl.onChange(getSession().getValue());
+  };
+
+  $ctrl.configEditor = () => {
+    setEditorMode(buildModePath($ctrl.mode));
+    setEditorOptions({ tabSize: 2 });
+    setEditorCode($ctrl.code);
+    listenChanges();
   };
 
   $ctrl.$onDestroy = () => {

--- a/src/webapp/scripts/components/code-editor/code-editor.test.js
+++ b/src/webapp/scripts/components/code-editor/code-editor.test.js
@@ -1,8 +1,17 @@
+import testingService from '@scripts/services/testing';
+
 describe('Code Editor', () => {
   let compile, $timeout;
 
   function getEditorInstance(element){
     return element.isolateScope().$ctrl.editor;
+  }
+
+  async function mount(props){
+    const element = compile(props);
+    await testingService.pause(10);
+    $timeout.flush();
+    return element;
   }
 
   beforeEach(() => {
@@ -25,61 +34,53 @@ describe('Code Editor', () => {
     console.warn = jest.fn();
   });
 
-  it('should have appropriate css class', () => {
-    const element = compile();
+  it('should have appropriate css class', async () => {
+    const element = await mount();
     expect(element.find('div').hasClass('p-code-editor')).toEqual(true);
   });
 
-  it('should listen for changes on initialization', () => {
-    const element = compile();
+  it('should listen for changes on editor config', async () => {
+    const element = await mount();
     const controller = element.isolateScope().$ctrl;
     const session = controller.editor.getSession();
     session.on = jest.fn();
-    controller.$onInit();
-    $timeout.flush();
+    controller.configEditor();
     expect(session.on).toHaveBeenCalledWith('change', controller.handleChange);
   });
 
-  it('should show no code by default', () => {
-    const element = compile();
+  it('should show no code by default', async () => {
+    const element = await mount();
     expect(getEditorInstance(element).getSession().getValue()).toEqual('');
   });
 
-  it('should optionally set an initial code', () => {
+  it('should optionally set an initial code', async () => {
     const code = 'const a = 1;';
-    const element = compile({ code });
+    const element = await mount({ code });
     expect(getEditorInstance(element).getSession().getValue()).toEqual(code);
   });
 
-  it('should optionally set a mode', () => {
+  it('should optionally set a mode', async () => {
     const mode = 'javascript';
-    const element = compile({ mode });
+    const element = await mount({ mode });
     expect(getEditorInstance(element).getSession().getMode().$id).toEqual('ace/mode/javascript');
   });
 
-  it('should execute change callback when code changes if callback has been given', () => {
+  it('should execute change callback when code changes if callback has been given', async () => {
     const onChange = jest.fn();
     const value = 'const a = 3;';
-    const element = compile({ onChange });
+    const element = await mount({ onChange });
     const editorSession = getEditorInstance(element).getSession();
     editorSession.setValue(value);
     element.isolateScope().$ctrl.handleChange();
     expect(onChange).toHaveBeenCalledWith(value);
   });
 
-  it('should not execute change callback when code changes if no callback has been given', () => {
-    const onChange = jest.fn();
-    const element = compile({ onChange });
-    delete element.isolateScope().$ctrl.onChange;
-    element.isolateScope().$ctrl.handleChange();
-    expect(onChange).not.toHaveBeenCalled();
-  });
-
-  it('should destroy editor on component destroy', () => {
-    const element = compile();
+  it('should destroy editor on component destroy', async () => {
+    const element = await mount();
     element.isolateScope().$ctrl.editor.destroy = jest.fn();
     element.isolateScope().$ctrl.$onDestroy();
+    const editorContainerEl = element[0].querySelector('[data-code-editor]');
     expect(element.isolateScope().$ctrl.editor.destroy).toHaveBeenCalled();
-    expect(element.html().trim()).toEqual('');
+    expect(editorContainerEl).toEqual(null);
   });
 });

--- a/src/webapp/scripts/services/analytics.js
+++ b/src/webapp/scripts/services/analytics.js
@@ -1,5 +1,5 @@
-import GAnalytics from '@glorious/analytics';
-import googleAnalyticsAdapter from '@glorious/analytics/dist/adapters/google-analytics';
+import Staly from '@compilorama/staly';
+import googleAnalyticsAdapter from '@compilorama/staly/dist/adapters/google-analytics';
 import externalGlobalDataService from '@scripts/services/external-global-data';
 import windowService from '@scripts/services/window';
 
@@ -16,11 +16,13 @@ _public.init = () => {
 };
 
 _public.trackPageView = () => {
-  analytics && analytics.trackPageview(analytics._getPageViewOptions());
+  analytics && setTimeout(() => {
+    analytics.trackPageview(analytics._getPageViewOptions());
+  });
 };
 
 function instantiateAnalytics({ id, type, options, getPageViewOptions }){
-  analytics = new GAnalytics();
+  analytics = new Staly();
   analytics.init(id, options);
   analytics._type = type;
   analytics._getPageViewOptions = getPageViewOptions;

--- a/src/webapp/scripts/services/analytics.test.js
+++ b/src/webapp/scripts/services/analytics.test.js
@@ -1,11 +1,11 @@
-import GAnalytics from '@glorious/analytics';
-import googleAnalyticsAdapter from '@glorious/analytics/dist/adapters/google-analytics';
+import Staly from '@compilorama/staly';
+import googleAnalyticsAdapter from '@compilorama/staly/dist/adapters/google-analytics';
 import testingService from '@scripts/services/testing';
-import { GAnalyticsMock, ganalyticsInstanceMock } from '@mocks/glorious-analytics';
+import { stalyMock, stalyInstanceMock } from '@mocks/staly';
 import windowService from '@scripts/services/window';
 import analyticsService from './analytics';
 
-GAnalytics.mockImplementation(GAnalyticsMock);
+Staly.mockImplementation(stalyMock);
 
 describe('Analytics Service', () => {
   function mockGoogleAnalyticsData(googleAnalyticsId){
@@ -21,25 +21,27 @@ describe('Analytics Service', () => {
   }
 
   beforeEach(() => {
-    ganalyticsInstanceMock.init = jest.fn();
-    ganalyticsInstanceMock.trackPageview = jest.fn();
+    jest.useFakeTimers();
+    stalyInstanceMock.init = jest.fn();
+    stalyInstanceMock.trackPageview = jest.fn();
     windowService.getHash = jest.fn(() => '#!/');
   });
 
   afterEach(() => {
     testingService.clearExternalGlobalData();
+    jest.useRealTimers();
   });
 
   it('should not initialize glorious analytics if no metrics data has been found', () => {
     analyticsService.init();
-    expect(ganalyticsInstanceMock.init).not.toHaveBeenCalled();
+    expect(stalyInstanceMock.init).not.toHaveBeenCalled();
   });
 
   it('should initialize analytics with Google Analytics by default', () => {
     const googleAnalyticsId = '123';
     mockGoogleAnalyticsData(googleAnalyticsId);
     analyticsService.init();
-    expect(ganalyticsInstanceMock.init).toHaveBeenCalledWith(
+    expect(stalyInstanceMock.init).toHaveBeenCalledWith(
       googleAnalyticsId,
       { adapter: googleAnalyticsAdapter }
     );
@@ -50,8 +52,9 @@ describe('Analytics Service', () => {
     mockGoogleAnalyticsData('123');
     analyticsService.init();
     analyticsService.trackPageView();
-    expect(ganalyticsInstanceMock.trackPageview).toHaveBeenCalledTimes(1);
-    expect(ganalyticsInstanceMock.trackPageview).toHaveBeenCalledWith({
+    jest.runOnlyPendingTimers();
+    expect(stalyInstanceMock.trackPageview).toHaveBeenCalledTimes(1);
+    expect(stalyInstanceMock.trackPageview).toHaveBeenCalledWith({
       path: '/components/vue/column'
     });
   });
@@ -60,7 +63,7 @@ describe('Analytics Service', () => {
     const plausibleId = 'some.website.com';
     mockPlausibleData({ plausibleId });
     analyticsService.init();
-    expect(ganalyticsInstanceMock.init).toHaveBeenCalledWith(plausibleId, {});
+    expect(stalyInstanceMock.init).toHaveBeenCalledWith(plausibleId, {});
   });
 
   it('should optionally pass options to Plausible initialization', () => {
@@ -68,7 +71,7 @@ describe('Analytics Service', () => {
     const plausibleOptions = { trackLocalhost: true };
     mockPlausibleData({ plausibleId, plausibleOptions });
     analyticsService.init();
-    expect(ganalyticsInstanceMock.init).toHaveBeenCalledWith(plausibleId, plausibleOptions);
+    expect(stalyInstanceMock.init).toHaveBeenCalledWith(plausibleId, plausibleOptions);
   });
 
   it('should optionally track page view using Plausible', () => {
@@ -76,7 +79,8 @@ describe('Analytics Service', () => {
     const plausibleId = 'some.website.com';
     mockPlausibleData({ plausibleId });
     analyticsService.trackPageView();
-    expect(ganalyticsInstanceMock.trackPageview).toHaveBeenCalledWith({
+    jest.runOnlyPendingTimers();
+    expect(stalyInstanceMock.trackPageview).toHaveBeenCalledWith({
       url: '/components/vue/form'
     });
   });

--- a/src/webapp/scripts/services/code-editor.js
+++ b/src/webapp/scripts/services/code-editor.js
@@ -1,0 +1,15 @@
+const _public = {};
+
+_public.load = () => {
+  return import(/* webpackChunkName: 'brace' */ 'brace').then(ace => {
+    return Promise.all([
+      import(/* webpackChunkName: 'brace-js-mode' */ 'brace/mode/javascript'),
+      import(/* webpackChunkName: 'brace-jsx-mode' */ 'brace/mode/jsx'),
+      import(/* webpackChunkName: 'brace-html-mode' */ 'brace/mode/html'),
+      import(/* webpackChunkName: 'brace-css-mode' */ 'brace/mode/css'),
+      import(/* webpackChunkName: 'code-editor-styles' */ '@styles/code-editor.styl')
+    ]).then(() => ace);
+  });
+};
+
+export default _public;

--- a/src/webapp/scripts/services/testing.js
+++ b/src/webapp/scripts/services/testing.js
@@ -10,4 +10,8 @@ _public.clearExternalGlobalData = () => {
   delete window[GLOBAL_DATA_KEY];
 };
 
+_public.pause = async timeout => {
+  return await new Promise(resolve => setTimeout(resolve, timeout));
+};
+
 export default _public;


### PR DESCRIPTION
Resolves https://github.com/glorious-codes/glorious-pitsby/issues/149

This Pull Request introduces the necessary changes to isolate all Ace Editor code in its own chunk. This chunk will be loaded only when users visit the Playground route.

Also: Replaces @glorious/analytics for @compilorama/staly

## Final Bundle Analysis (Main bundle now has only 75kb Gziped)
<img width="1440" alt="Screen Shot 2023-11-18 at 17 54 20" src="https://github.com/glorious-codes/glorious-pitsby/assets/4738687/7a891d77-ce93-4cba-97e6-8945245e739a">
